### PR TITLE
use toArrayBuffer() only when present

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,11 @@ Level.prototype._put = function (key, value, options, callback) {
   }
   var obj = this.convertEncoding(key, value, options)
   if (Buffer.isBuffer(obj.value)) {
-    obj.value = new Uint8Array(value.toArrayBuffer())
+    if (typeof value.toArrayBuffer === 'function') {
+      obj.value = new Uint8Array(value.toArrayBuffer())
+    } else {
+      obj.value = new Uint8Array(value)
+    }
   }
   this.idb.put(obj.key, obj.value, function() { callback() }, callback)
 }


### PR DESCRIPTION
toArrayBuffer() was removed in node core a long time ago and was removed from browserify's buffer implementation in january: https://github.com/feross/buffer/issues/90

This patch guards the call to toArrayBuffer() only when it's present.

Fixes #50.